### PR TITLE
Deleting the QNetworkManager instance too early may lead to crashes.

### DIFF
--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -56,6 +56,12 @@ qRestAPIPrivate::qRestAPIPrivate(qRestAPI* object)
 }
 
 // --------------------------------------------------------------------------
+qRestAPIPrivate::~qRestAPIPrivate()
+{
+  NetworkManager->deleteLater();
+}
+
+// --------------------------------------------------------------------------
 void qRestAPIPrivate::staticInit()
 {
   qRegisterMetaType<QUuid>("QUuid");
@@ -65,8 +71,7 @@ void qRestAPIPrivate::staticInit()
 // --------------------------------------------------------------------------
 void qRestAPIPrivate::init()
 {
-  Q_Q(qRestAPI);
-  this->NetworkManager = new QNetworkAccessManager(q);
+  this->NetworkManager = new QNetworkAccessManager();
   QObject::connect(this->NetworkManager, SIGNAL(finished(QNetworkReply*)),
                    this, SLOT(processReply(QNetworkReply*)));
 #ifndef QT_NO_OPENSSL

--- a/qRestAPI_p.h
+++ b/qRestAPI_p.h
@@ -59,6 +59,7 @@ private:
 
 public:
   qRestAPIPrivate(qRestAPI* object);
+  ~qRestAPIPrivate();
 
   virtual void init();
 


### PR DESCRIPTION
The qRestAPIPrivate::NetworkManager member was created with a
qRestAPI\* parent which lead to the immediate destruction of the
QNetworkManager instance when the qRestAPI instance was deleted.
In turn, this lead to network errors and subsequent crashes in
some scenarios where QNetworkReply instances where still alive.
Not putting qRestAPIPrivate::NetworkManager in a QObject hierarchy
and explicitly calling "deleteLater()" on it solves this issue.
