### PR TITLE
Restore Qt 4.6.2 compatibility.

### DIFF
--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -26,6 +26,7 @@
 #include <QStringList>
 #include <QTimer>
 #include <QUuid>
+#include <QScriptValueIterator>
 
 // qRestAPI includes
 #include "qRestAPI.h"
@@ -212,10 +213,17 @@ void qRestAPIPrivate::processReply(QNetworkReply* reply)
     q->parseResponse(restResult, response);
     }
 
-  foreach(const QNetworkReply::RawHeaderPair& rawHeaderPair, reply->rawHeaderPairs())
-    {
-    restResult->setRawHeader(rawHeaderPair.first, rawHeaderPair.second);
-    }
+  #if QT_VERSION >= QT_VERSION_CHECK(4, 7, 0)
+    foreach(const QNetworkReply::RawHeaderPair& rawHeaderPair, reply->rawHeaderPairs())
+      {
+      restResult->setRawHeader(rawHeaderPair.first, rawHeaderPair.second);
+      }
+  #else
+    foreach(const QByteArray& headerName, reply->rawHeaderList())
+      {
+      restResult->setRawHeader(headerName, reply->rawHeader(headerName));
+      }
+  #endif
 
   reply->close();
   reply->deleteLater();


### PR DESCRIPTION
qRestAPI states a minimum required Qt version of 4.6.2 but does not compile with that version. This patch restores compatibility with Qt 4.6.2.
