### PR TITLE
Fix compiling with Qt5 without OpenSSL

### DIFF
--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -78,7 +78,7 @@ void qRestAPIPrivate::init()
   this->NetworkManager = new QNetworkAccessManager();
   QObject::connect(this->NetworkManager, SIGNAL(finished(QNetworkReply*)),
                    this, SLOT(processReply(QNetworkReply*)));
-#ifndef QT_NO_OPENSSL
+#ifndef QRESTAPI_NO_SSL
   if (QSslSocket::supportsSsl())
     {
     QObject::connect(this->NetworkManager, SIGNAL(sslErrors(QNetworkReply*, QList<QSslError>)),
@@ -243,9 +243,12 @@ void qRestAPIPrivate::processReply(QNetworkReply* reply)
   reply->deleteLater();
 }
 
-#ifndef QT_NO_OPENSSL
 void qRestAPIPrivate::onSslErrors(QNetworkReply* reply, const QList<QSslError>& errors)
 {
+#ifdef QRESTAPI_NO_SSL
+  Q_UNUSED(reply)
+  Q_UNUSED(errors)
+#else
   if (!this->SuppressSslErrors)
     {
     QString errorString;
@@ -270,8 +273,8 @@ void qRestAPIPrivate::onSslErrors(QNetworkReply* reply, const QList<QSslError>& 
     {
     reply->ignoreSslErrors();
     }
-}
 #endif
+}
 
 // --------------------------------------------------------------------------
 void qRestAPIPrivate::queryProgress(qint64 bytesTransmitted, qint64 bytesTotal)

--- a/qRestAPI_p.h
+++ b/qRestAPI_p.h
@@ -28,14 +28,26 @@
 #endif
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
-#ifndef QT_NO_OPENSSL
-  #include <QSslError>
-#endif
+#include <QSslError>
 
 // qRestAPI includes
 #include "qRestAPI.h"
 
 class QIODevice;
+
+#if (QT_VERSION < QT_VERSION_CHECK(5, 3, 0))
+#ifdef QT_NO_OPENSSL
+#define QRESTAPI_QT_NO_SSL
+#endif
+#else
+#ifdef QT_NO_SSL
+#define QRESTAPI_QT_NO_SSL
+#endif
+#endif
+
+#ifdef QRESTAPI_QT_NO_SSL
+struct QSslError{};
+#endif
 
 // --------------------------------------------------------------------------
 class qRestAPIPrivate : public QObject
@@ -72,9 +84,7 @@ public slots:
   void downloadProgress(qint64 bytesReceived, qint64 bytesTotal);
   void uploadProgress(qint64 bytesSent, qint64 bytesTotal);
 
-#ifndef QT_NO_OPENSSL
   void onSslErrors(QNetworkReply* reply, const QList<QSslError>& errors);
-#endif
 
 //  void onAuthenticationRequired(QNetworkReply* reply, QAuthenticator* authenticator);
 


### PR DESCRIPTION
Qt 5.3 added a the macro QT_NO_SSL that indicates whether any SSL
support is available, not necessarily OpenSSL. The QT_NO_OPENSSL macro
still exists but its meaning is changed to indicate whether OpenSSL is
available, not any SSL support.

See https://gitlab.com/pteam/korvins-qtbase/commit/b328e36e41dc0c529c897fe845c53be1d39424be.

This fixes the following error compiling with the official Qt5 Mac
installer:

```
    qRestAPI_p.cpp:102:21: error: no member named 'onSslErrors' in 'qRestAPIPrivate'
        case 5: _t->onSslErrors((*reinterpret_cast<
        QNetworkReply*(*)>(_a[1])),(*reinterpret_cast< const
        QList<QSslError>(*)>(_a[2]))); break;
```