### PR TITLE
BUG: fix timout in qMidasAPI::synchronousQuery()

### DIFF
--- a/qMidasAPI.cpp
+++ b/qMidasAPI.cpp
@@ -91,16 +91,17 @@ QList<QVariantMap> qMidasAPI::synchronousQuery(
   if(restResult)
     {
     result = restResult->results();
-    if (restResult->errorType() != qRestAPI::NoError)
-      {
-      QVariantMap map;
-      map["queryError"] = restResult->error();
-      result.push_front(map);
-      }
-    else
-      {
-      ok = true;
-      }
+    }
+  
+  if (restAPI.error() != qRestAPI::UnknownError)
+    {
+    QVariantMap map;
+    map["queryError"] = restAPI.errorString();
+    result.push_front(map);
+    }
+  else
+    {
+    ok = true;
     }
   
   if (result.count() == 0)

--- a/qMidasAPI.cpp
+++ b/qMidasAPI.cpp
@@ -21,6 +21,7 @@
 // Qt includes
 #include <QEventLoop>
 #include <QUrl>
+#include <QScopedPointer>
 #if (QT_VERSION >= QT_VERSION_CHECK(5,0,0))
 #include <QUrlQuery>
 #endif
@@ -29,20 +30,6 @@
 #include "qMidasAPI.h"
 #include "qMidasAPI_p.h"
 #include "qRestResult.h"
-
-// --------------------------------------------------------------------------
-void qMidasAPIResult::setResult(const QUuid& queryUuid, const QList<QVariantMap>& result)
-{
-  this->QueryUuid = queryUuid;
-  this->Result = result;
-}
-
-// --------------------------------------------------------------------------
-void qMidasAPIResult::setError(const QUuid& queryUuid, const QString& error)
-{
-  Q_UNUSED(queryUuid);
-  this->Error += error;
-}
 
 // --------------------------------------------------------------------------
 // qMidasAPIPrivate methods
@@ -97,33 +84,28 @@ QList<QVariantMap> qMidasAPI::synchronousQuery(
   restAPI.setServerUrl(serverUrl);
   restAPI.setTimeOut(maxWaitingTimeInMSecs);
   QUuid queryUuid = restAPI.get(method, parameters);
-  Q_UNUSED(queryUuid);
-  qMidasAPIResult queryResult;
-  QObject::connect(&restAPI, SIGNAL(resultReceived(QUuid,QList<QVariantMap>)),
-                   &queryResult, SLOT(setResult(QUuid,QList<QVariantMap>)));
-  QObject::connect(&restAPI, SIGNAL(errorReceived(QUuid,QString)),
-                   &queryResult, SLOT(setError(QUuid,QString)));
-  QEventLoop eventLoop;
-  QObject::connect(&restAPI, SIGNAL(resultReceived(QUuid,QList<QVariantMap>)),
-                   &eventLoop, SLOT(quit()));
-  // Time out will fire an error which will quit the event loop.
-  QObject::connect(&restAPI, SIGNAL(errorReceived(QUuid,QString)),
-                   &eventLoop, SLOT(quit()));
-  eventLoop.exec();
-  ok = queryResult.Error.isNull();
-  if (!ok)
+  
+  QList<QVariantMap> result;
+  QScopedPointer<qRestResult> restResult(restAPI.takeResult(queryUuid));
+  if(restResult)
     {
-    QVariantMap map;
-    map["queryError"] = queryResult.Error;
-    queryResult.Result.push_front(map);
+    result = restResult->results();
+    if (restResult->errorType() != qRestAPI::NoError)
+      {
+      QVariantMap map;
+      map["queryError"] = restResult->error();
+      result.push_front(map);
+      }
     }
-  if (queryResult.Result.count() == 0)
+  
+  if (result.count() == 0)
     {
     QVariantMap map;
     map["queryError"] = tr("Unknown error");
-    queryResult.Result.push_front(map);
+    result.push_front(map);
     }
-  return queryResult.Result;
+
+  return result;
 }
 
 // --------------------------------------------------------------------------

--- a/qMidasAPI.cpp
+++ b/qMidasAPI.cpp
@@ -86,6 +86,7 @@ QList<QVariantMap> qMidasAPI::synchronousQuery(
   QUuid queryUuid = restAPI.get(method, parameters);
   
   QList<QVariantMap> result;
+  ok = false;
   QScopedPointer<qRestResult> restResult(restAPI.takeResult(queryUuid));
   if(restResult)
     {
@@ -95,6 +96,10 @@ QList<QVariantMap> qMidasAPI::synchronousQuery(
       QVariantMap map;
       map["queryError"] = restResult->error();
       result.push_front(map);
+      }
+    else
+      {
+      ok = true;
       }
     }
   

--- a/qMidasAPI_p.h
+++ b/qMidasAPI_p.h
@@ -45,18 +45,4 @@ public:
   qMidasAPIPrivate(qMidasAPI* object);
 };
 
-// --------------------------------------------------------------------------
-class qMidasAPIResult : public QObject
-{
-  Q_OBJECT
-public:
-  QUuid QueryUuid;
-  QList<QVariantMap> Result;
-  QString Error;
-
-public slots:
-  void setResult(const QUuid& queryUuid, const QList<QVariantMap>& result);
-  void setError(const QUuid& queryUuid, const QString& error);
-};
-
 #endif

--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -217,7 +217,7 @@ void qRestAPIPrivate::processReply(QNetworkReply* reply)
     default:
       ;
       }
-    restResult->setError(queryId.toString() + ": "  +
+    restResult->setError(queryId.toString() + ": " +
                          QString::number(static_cast<int>(reply->error())) + ": " +
                          reply->errorString(),
                          errorCode);
@@ -529,7 +529,7 @@ QUuid qRestAPI::put(QIODevice *input, const QString &resource, const qRestAPI::P
     {
     QUuid uid = QUuid::createUuid();
     qRestResult* restResult = new qRestResult(uid);
-    restResult->setError(uid.toString() + ": "  +
+    restResult->setError(uid.toString() + ": " +
                          "Could not open file for upload!",
                          qRestAPI::FileError);
     d->results[uid] = restResult;

--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -198,6 +198,7 @@ void qRestAPIPrivate::processReply(QNetworkReply* reply)
   QUuid queryId(reply->property("uuid").toString());
 
   qRestResult* restResult = results[queryId];
+  Q_ASSERT(restResult);
 
   if (reply->error() != QNetworkReply::NoError)
     {


### PR DESCRIPTION
Since qRestAPI was extracted for XNAT, the new error handling in
qRestAPIPrivate::processReply() would kick in before the old error
handling can ever see the error (in parseResponse()).  That refactoring
broke timeout handing in qMidasAPI::synchronousQuery().

This PR further refactors qMidasAPI and makes more use of the new
qRestAPI.  In particular, the local eventLoop in synchronousQuery() is
ditched in favor of qRestAPI::waitForDone().