### PR TITLE
Small refactoring / testing improvements

### DIFF
--- a/Testing/qMidasAPITest.cpp
+++ b/Testing/qMidasAPITest.cpp
@@ -55,6 +55,7 @@ int qMidasAPITest(int argc, char* argv[])
   // --------------------------------------------------------------------------
   // Check that query associated with local file release file handle
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Check that query associated with local file release file handle ===" << std::endl;
   QDir tmp = QDir::temp();
   QString temporaryDirName =
         QString("qMidasAPITest1-queryFile.%1").arg(QTime::currentTime().toString("hhmmsszzz"));
@@ -108,8 +109,9 @@ int qMidasAPITest(int argc, char* argv[])
     }
 
   // --------------------------------------------------------------------------
-  // Successfull query: midas.version
+  // Successful query: midas.version
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Successful query: midas.version ===" << std::endl;
   QSignalSpy errorSpy(&midasAPI, SIGNAL(errorReceived(QUuid,QString)));
   QSignalSpy receivedSpy(&midasAPI, SIGNAL(resultReceived(QUuid,QList<QVariantMap>)));
   QUuid queryUuid = midasAPI.get("midas.version");
@@ -132,6 +134,7 @@ int qMidasAPITest(int argc, char* argv[])
   // --------------------------------------------------------------------------
   // Fail query: midas.notafunction
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Fail query: midas.notafunction ===" << std::endl;
   queryUuid = midasAPI.get("midas.notafunction");
 
   // Give 5 seconds for the server to answer
@@ -151,6 +154,7 @@ int qMidasAPITest(int argc, char* argv[])
   // --------------------------------------------------------------------------
   // Synchronous query: midas.info
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Synchronous query: midas.info ===" << std::endl;
   ok = false;
   result  = qMidasAPI::synchronousQuery(ok, midasUrl, "midas.info");
   std::cout << "result: " <<
@@ -165,6 +169,7 @@ int qMidasAPITest(int argc, char* argv[])
   // --------------------------------------------------------------------------
   // Synchronous fail query: midas.notafunction
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Synchronous fail query: midas.notafunction ===" << std::endl;
   result= qMidasAPI::synchronousQuery(ok, midasUrl,"midas.notafunction");
   std::cout << "result: " <<
     qPrintable(qMidasAPI::qVariantMapListToString(result))<< std::endl;
@@ -181,6 +186,7 @@ int qMidasAPITest(int argc, char* argv[])
   // --------------------------------------------------------------------------
   // Synchronous fail query: midas.login (wrong credentials)
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Synchronous fail query: midas.login (wrong credentials) ===" << std::endl;
   qMidasAPI::ParametersType wrongParameters;
   wrongParameters["appname"] = "qMidasAPITest";
   wrongParameters["email"] = "john.doe@mail.com";
@@ -201,6 +207,7 @@ int qMidasAPITest(int argc, char* argv[])
   // --------------------------------------------------------------------------
   // Synchronous query: midas.community.list (return array of data)
   // --------------------------------------------------------------------------
+  std::cout << "\n=== Synchronous query: midas.community.list (return array of data) ===" << std::endl;
   result= qMidasAPI::synchronousQuery(ok, midasUrl,"midas.community.list");
   std::cout << "result: " <<
     qPrintable(qMidasAPI::qVariantMapListToString(result))<< std::endl;

--- a/Testing/qMidasAPITest.cpp
+++ b/Testing/qMidasAPITest.cpp
@@ -122,7 +122,7 @@ int qMidasAPITest(int argc, char* argv[])
       receivedSpy.count() != 1)
     {
     std::cerr << "Failed to query 'midas.version': "
-              << errorSpy.count() << " errors,"
+              << errorSpy.count() << " errors, "
               << receivedSpy.count() << " results." << std::endl;
     return EXIT_FAILURE;
     }
@@ -143,7 +143,7 @@ int qMidasAPITest(int argc, char* argv[])
       receivedSpy.count() != 1)
     {
     std::cerr << "Failed to query 'midas.notafunction': "
-              << errorSpy.count() << " errors,"
+              << errorSpy.count() << " errors, "
               << receivedSpy.count() << " results." << std::endl;
     return EXIT_FAILURE;
     }
@@ -172,7 +172,7 @@ int qMidasAPITest(int argc, char* argv[])
       result.size() != 1 ||
       result.at(0)["queryError"].isNull())
     {
-    std::cout << "Failed to query 'midas.info'."
+    std::cout << "Failed to query 'midas.info'. Got "
               << result.size() << " results."
               << std::endl;
     return EXIT_FAILURE;
@@ -192,7 +192,7 @@ int qMidasAPITest(int argc, char* argv[])
       result.size() != 1 ||
       result.at(0)["queryError"].isNull())
     {
-    std::cout << "Failed to query 'midas.login'."
+    std::cout << "Failed to query 'midas.login'. Got "
               << result.size() << " results."
               << std::endl;
     return EXIT_FAILURE;

--- a/qMidasAPI.cpp
+++ b/qMidasAPI.cpp
@@ -161,7 +161,7 @@ void qMidasAPI::parseResponse(qRestResult* restResult, const QByteArray& respons
     {
     QString error = QString("Error while parsing outputs:") +
       " status: " + scriptValue.property("stat").toString() +
-      " code: " + scriptValue.property("code").toInteger() +
+      " code: " + QString::number(scriptValue.property("code").toInteger()) +
       " msg: " + scriptValue.property("message").toString();
     restResult->setError(error, ResponseParseError);
     emit errorReceived(queryId, error);

--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -614,6 +614,8 @@ qRestResult* qRestAPI::takeResult(const QUuid& queryId)
   Q_D(qRestAPI);
   if (d->results.contains(queryId))
     {
+    // Do /not/ try to .take() the query before calling waitForDone();
+    // the latter triggers SIGNALs which access d->results.
     bool ok = d->results[queryId]->waitForDone();
     qRestResult* result = d->results.take(queryId);
     if (ok)

--- a/qRestResult.h
+++ b/qRestResult.h
@@ -56,7 +56,9 @@ public:
 
   const QList<QVariantMap>& results() const;
   const QVariantMap result() const;
+  // FIXME: for consistency with the qRestAPI class, this method should be called errorString()
   const QString& error() const;
+  // FIXME: for consistency with the qRestAPI class, this method should be called error()
   qRestAPI::ErrorType errorType() const;
 
   QByteArray rawHeader(const QByteArray& name) const;
@@ -64,7 +66,7 @@ public:
 
 public slots:
   void setResult();
-  void setResult(const QList<QVariantMap>& result);
+  void setResult(const QList<QVariantMap>& result); // FIXME: should be called setResults(), see getters
   void setError(const QString& error, qRestAPI::ErrorType errorType = qRestAPI::UnknownError);
 
   void downloadReadyRead();


### PR DESCRIPTION
This is a series of tiny changes that mostly improve the tests or add FIXME comments.

The only change to the qMidasAPI is to properly format remote error codes.  Previously, it would output:
```
result: queryError: Error while parsing outputs: status: fail code:  msg: Server error. Requested method midas.notafunction does not exist.No data
```
With this fix, it becomes
```
result: queryError: Error while parsing outputs: status: fail code: -101 msg: Server error. Requested method midas.notafunction does not exist.No data
```
