### PR TITLE
ENH: safer parse: use QScriptEngine JSON.parse internal function

### DIFF
--- a/qMidasAPI.cpp
+++ b/qMidasAPI.cpp
@@ -151,7 +151,10 @@ QUrl qMidasAPI::createUrl(const QString& method, const qRestAPI::Parameters& par
 void qMidasAPI::parseResponse(qRestResult* restResult, const QByteArray& response)
 {
   Q_D(qMidasAPI);
-  QScriptValue scriptValue = d->ScriptEngine.evaluate("(" + QString(response) + ")");
+  QScriptValue scriptValue = d->ScriptEngine
+                                .evaluate("JSON.parse")
+                                .call(QScriptValue(),
+                                      QScriptValueList() << QString(response));
 
   QUuid queryId = restResult->queryId();
 


### PR DESCRIPTION
...instead of eval'ing directly from network. Bug found by Hans Meine (@-hmeine).

Solution from this Qt tracker issue:

  https://bugreports.qt.io/browse/QTBUG-5757