### PR TITLE
BUG: Follow redirects in requests in Qt5

### DIFF
--- a/qRestAPI.cpp
+++ b/qRestAPI.cpp
@@ -110,6 +110,11 @@ QNetworkReply* qRestAPI::sendRequest(QNetworkAccessManager::Operation operation,
   QNetworkRequest queryRequest;
   queryRequest.setUrl(url);
 
+#if (QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
+  // In Qt6, redirects are followed by default, but it has to be manually enabled in Qt5.
+  queryRequest.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+#endif 
+
   for (QMapIterator<QByteArray, QByteArray> it(d->DefaultRawHeaders); it.hasNext();)
     {
     it.next();


### PR DESCRIPTION
In Qt6, redirects are enabled by default but it has to be enabled manually in Qt5.

Redirects are useful because they allow implementing GET web requests that contain query parameters by only using static HTML pages that can be easily hosted, without having to set up a database (e.g., on GitHub pages).

For example, 3D Slicer extension catalog extension list query request (API call https://example.com/api/v1/app/5f4474d0e1d8c75dfc705482/extension?app_revision=32438&arch=amd64&limit=0&os=win) can be implemented by having a static page (https://example.com/api/v1/app/5f4474d0e1d8c75dfc705482/extension/index.html) containing JavaScript that redirects to the extensions list json file (https://example.com/api/v1/app/5f4474d0e1d8c75dfc705482/extension/extensions-32438-amd64-win.json).